### PR TITLE
Add support for reading bits, Add Multiple Memory Reads & migrate to safe buffer constructor methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is an implementation of the [OMRON FINS protocol](https://www.google.com/se
 ### Supported Commands:
 
 * Memory area read
+* Multiple memory area read
 * Memory area write
 * Memory area fill
 * Controller status read
@@ -84,6 +85,16 @@ Memory Area Read Command
 client.read('D00000',10,function(err,bytes) {
 	console.log("Bytes: ", bytes);
 });
+```
+
+##### .readMultiple(address(es))
+Multiple Memory Area Read Command 
+* `address` - Memory area and the numerical start address
+
+```js
+ /* Reads multiple registers from different memory areas, you can mix and match words and bit reads */
+.readMultiple('D100','H10','CB80:03','H22');
+
 ```
 
 ##### .write(address, dataToBeWritten, callback)

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -14,7 +14,7 @@ client.on('error',function(error) {
 */
 
 client.on('reply',function(msg) {
-  console.log("Reply from: ", msg.remotehost);
+    console.log("Reply from: ", msg.remotehost);
     console.log("Replying to issued command of: ", msg.command);
     console.log("Response code of: ", msg.code);
     console.log("Data returned: ", msg.values);
@@ -24,7 +24,11 @@ client.on('reply',function(msg) {
 /* Read 10 registers starting at DM register 00000 */
 client.read('D00000',10,function(err,bytes) {
 	console.log("Bytes: ", bytes);
+});
 
+/* Read CIO bit 1.00 */
+client.read('CB1:00',1,function(err,bytes) {
+	console.log("Bytes: ", bytes);
 });
 
 /* Write 1337 to DM register 00000 */

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -31,6 +31,9 @@ client.read('CB1:00',1,function(err,bytes) {
 	console.log("Bytes: ", bytes);
 });
 
+/* Read WORDS or BITS from multiple memory address in one command */
+client.readMultiple('H18','W32','H20','CB80:03','H22');
+
 /* Write 1337 to DM register 00000 */
 client.write('D00000',1337)
 

--- a/examples/multpleClients.js
+++ b/examples/multpleClients.js
@@ -8,7 +8,7 @@ var clients = [];
 /* Hold both successful and failed communication attempts */
 var responses = [];
 
-/* 
+/*
     List of remote hosts
     More than likely will be generated from external source
 */
@@ -17,7 +17,7 @@ var remoteHosts = ['127.0.0.1','127.0.0.2','127.0.0.3'];
 
 
 /*
-    This method will be executed once we know all communications 
+    This method will be executed once we know all communications
     have either timed out or responded accordingly. This is where
     data will be processed (database,api,etc)
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -65,12 +65,16 @@ module.exports.Modes = {
 
 
 module.exports.MemoryAreas = {
-    'E' : 0xA0,//Extended Memories
-    'C' : 0xB0,//CIO
-    'W' : 0xB1,//Work Area
-    'H' : 0xB2,//Holding Bit
-    'A' : 0xB3,//Auxiliary Bit
-    'D' : 0x82//Data Memories
+    'E'  : 0xA0,//Extended Memories
+    'C'  : 0xB0,//CIO
+    'CB' : 0x30,//CIO reading in bit
+    'W'  : 0xB1,//Work Area
+    'WB' : 0x31,//Work Area reading in bit
+    'H'  : 0xB2,//Holding Bit
+    'HB' : 0x32,//Holding Bit reading in bit
+    'A'  : 0xB3,//Auxiliary Bit
+    'AB' : 0x33,//Auxiliary Bit reading in bit
+    'D'  : 0x82//Data Memories
 };
 
 module.exports.Errors = {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -27,6 +27,7 @@ module.exports.DefaultFinsHeader = {
 module.exports.Commands = {
     CONTROLLER_STATUS_READ : [0x06,0x01],
     MEMORY_AREA_READ       : [0x01,0x01],
+    MEMORY_AREA_READ_MULTI : [0x01,0x04],
     MEMORY_AREA_WRITE      : [0x01,0x02],
     MEMORY_AREA_FILL       : [0x01,0x03],
     RUN                    : [0x04,0x01],

--- a/lib/fins_client.js
+++ b/lib/fins_client.js
@@ -70,28 +70,29 @@ _wordsToBytes = function(words) {
 
 
 _translateMemoryAddress = function(memoryAddress) {
-    var re = /(.)([0-9]*):?([0-9]*)/;
+    var re = /([A-Z]*)([0-9]*):?([0-9]*)/;
     var matches = memoryAddress.match(re);
-    var decodedMemory = {
-        'MemoryArea':matches[1],
-        'Address':matches[2],
-        'Bit':matches[3]
-    };
-
+    var area = matches[1];
+    var addr = matches[2];
+    var bit  = matches[3];
     var temp = [];
-    var byteEncodedMemory = [];
 
-    if(!constants.MemoryAreas[decodedMemory['MemoryArea']]) {
+    if(!constants.MemoryAreas[area]) {
         temp.push([0x82]);
     } else {
-         temp.push([constants.MemoryAreas[decodedMemory['MemoryArea']]]);
+        temp.push(constants.MemoryAreas[area]);
     }
 
-     temp.push(_wordsToBytes([decodedMemory['Address']]));
-     temp.push([0x00]);
-     byteEncodedMemory = _mergeArrays(temp);
+    temp.push(_wordsToBytes([addr]));
 
-    return byteEncodedMemory;
+    if (!bit) {
+      bit = 0x00;
+    }
+    bit &= 0x0f;
+
+    temp.push(bit);
+
+    return _mergeArrays(temp);
 };
 
 _incrementSID = function(sid) {
@@ -173,10 +174,19 @@ _processMemoryAreaRead = function(buf,rinfo) {
     var command = (buf.slice(10,12)).toString("hex");
     var response = (buf.slice(12,14)).toString("hex");
     var values = (buf.slice(14,buf.length));
-    for(var i = 0; i < values.length; i+=2) {
-        data.push(values.readInt16BE(i));
+
+    // buffer is 14 bits command plus the value, if it is 15 then it is a bit, 16+ will be a 16bit int etc
+    if(buf.length==15){
+      // Note we are not returning an array just 1 value
+      return {remotehost:rinfo.address,sid:sid,command:command,response:response,values:values.readInt8(0)};
     }
-    return {remotehost:rinfo.address,sid:sid,command:command,response:response,values:data};
+    else{ // 16+ bit response
+      for(var i = 0; i < values.length; i+=2) {
+        data.push(values.readInt16BE(i));
+      }
+     // this returns an array
+     return {remotehost:rinfo.address,sid:sid,command:command,response:response,values:data};
+    }
 };
 
 
@@ -198,6 +208,8 @@ _processReply = function(buf,rinfo) {
     };
 
 };
+
+
 _decodePacket = function(buf,rinfo) {
     var data = [];
     var command = (buf.slice(10,12)).toString("hex");
@@ -333,5 +345,5 @@ FinsClient.prototype.close = function(){
         clearTimeout(this.timer);
         this.timer = undefined;
     }
-	this.socket.close();
+    this.socket.close();
 };

--- a/lib/fins_client.js
+++ b/lib/fins_client.js
@@ -190,6 +190,29 @@ _processMemoryAreaRead = function(buf,rinfo) {
 };
 
 
+_processMemoryAreaReadMultiple = function(buf,rinfo) {
+    var bits = ['30','31','32','33','B2','B3']; // hex values of memory addresses we support which read a bit
+    var data = [];
+    var sid = buf[9];
+    var command = (buf.slice(10,12)).toString("hex");
+    var response = (buf.slice(12,14)).toString("hex");
+    var values = (buf.slice(14,buf.length));
+
+    for(var i=0; i<values.length;){
+      var memarea = values[i++].toString(16); // get the HEX value of the mem area
+
+      if(bits.includes(memarea)){ // if we read a bit only read one element of the buffer
+        data.push(values.readInt8(i)); // not sure if readInt8() is needed, could we just push values[i] instead
+        i++; // move to the next memory area
+      }
+      else{
+        data.push(values.readInt16BE(i));
+        i=i+2; // move to the next memory area
+      }
+    }
+    return {remotehost:rinfo.address,sid:sid,command:command,response:response,values:data};
+};
+
 _processReply = function(buf,rinfo) {
     var commands = constants.Commands;
     var responseType = (_getResponseType(buf)).join(' ');
@@ -201,6 +224,10 @@ _processReply = function(buf,rinfo) {
 
         case commands.MEMORY_AREA_READ.join(' '):
             return _processMemoryAreaRead(buf,rinfo);
+            break;
+
+        case commands.MEMORY_AREA_READ_MULTI.join(' '):
+            return _processMemoryAreaReadMultiple(buf,rinfo);
             break;
 
         default:
@@ -278,6 +305,20 @@ FinsClient.prototype.read = function(address,regsToRead,callback) {
     var packet = _buildPacket([header,command,commandData]);
     var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
+};
+
+FinsClient.prototype.readMultiple = function() { // no callback not sure how to handle this with an unknown number of arguments
+    var self = this;
+    self.header.SID = _incrementSID(self.header.SID);
+    var header = _buildHeader(self.header);
+    var command = constants.Commands.MEMORY_AREA_READ_MULTI;
+    var commandData = []; // tmp array to push all the arguments memory address onto
+    for(i=0; i<arguments.length;i++){
+      commandData.push(_translateMemoryAddress(arguments[i]));
+    }
+    var packet = _buildPacket([header,command,commandData]);
+    var buffer = Buffer.from(packet);
+    this.socket.send(buffer,0,buffer.length,self.port,self.host); // we do not return a callback
 };
 
 FinsClient.prototype.write = function(address,dataToBeWritten,callback) {

--- a/lib/fins_client.js
+++ b/lib/fins_client.js
@@ -47,7 +47,6 @@ _keyFromValue = function(dict,value) {
     return key;
 };
 
-  
 
 _padHex = function (width,number) {
     return("0"*width + number.toString(16).substr(-width));
@@ -67,12 +66,11 @@ _wordsToBytes = function(words) {
         }
     }
     return bytes;
-
 };
 
 
 _translateMemoryAddress = function(memoryAddress) {
-    var re = /(.)([0-9]*):?([0-9]*)/; 
+    var re = /(.)([0-9]*):?([0-9]*)/;
     var matches = memoryAddress.match(re);
     var decodedMemory = {
         'MemoryArea':matches[1],
@@ -94,8 +92,6 @@ _translateMemoryAddress = function(memoryAddress) {
      byteEncodedMemory = _mergeArrays(temp);
 
     return byteEncodedMemory;
-
-  
 };
 
 _incrementSID = function(sid) {
@@ -113,10 +109,9 @@ _buildHeader = function(header) {
         header.SNA,
         header.SA1,
         header.SA2,
-        header.SID 
+        header.SID
     ];
     return builtHeader;
-
 };
 
 _buildPacket = function(raw) {
@@ -126,7 +121,6 @@ _buildPacket = function(raw) {
 };
 
 _getResponseType = function(buf) {
-    
     var response = [];
     response.push(buf[10]);
     response.push(buf[11]);
@@ -138,7 +132,6 @@ _processDefault = function(buf,rinfo) {
     var command = (buf.slice(10,12)).toString("hex");
     var response = (buf.slice(12,14)).toString("hex");
     return {remotehost:rinfo.address,sid:sid,command:command,response:response};
-
 };
 
 _processStatusRead = function(buf,rinfo) {
@@ -148,7 +141,7 @@ _processStatusRead = function(buf,rinfo) {
     var status = buf[14];
     var mode = buf[15];
     var fatalErrorData = {};
-    var nonFatalErrorData = {};    
+    var nonFatalErrorData = {};
     for(var i in constants.FatalErrorData) {
         if((buf.readInt16BE(17) & constants.FatalErrorData[i]) !=0 )
             fatalErrorData.push(i);
@@ -190,10 +183,9 @@ _processMemoryAreaRead = function(buf,rinfo) {
 _processReply = function(buf,rinfo) {
     var commands = constants.Commands;
     var responseType = (_getResponseType(buf)).join(' ');
-    
+
     switch(responseType) {
-       
-        case commands.CONTROLLER_STATUS_READ.join(' ') : 
+        case commands.CONTROLLER_STATUS_READ.join(' '):
             return _processStatusRead(buf,rinfo);
             break;
 
@@ -203,7 +195,6 @@ _processReply = function(buf,rinfo) {
 
         default:
             return _processDefault(buf,rinfo);
-
     };
 
 };
@@ -334,8 +325,6 @@ FinsClient.prototype.status = function(callback) {
     var packet = _buildPacket([header,command]);
     var buffer = new Buffer(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
-
-
 };
 
 
@@ -346,5 +335,3 @@ FinsClient.prototype.close = function(){
     }
 	this.socket.close();
 };
-
-

--- a/lib/fins_client.js
+++ b/lib/fins_client.js
@@ -254,8 +254,9 @@ FinsClient.init = function (port,host,options) {
     this.socket.on('error',error);
 
     if(this.timeout){
-        setTimeout(function cb_setTimeout() {
+        this.timer = setTimeout(function cb_setTimeout() {
             if(self.responded == false){
+                self.timer = undefined;
                 self.emit('timeout',self.host);
             }
         },self.timeout);
@@ -339,7 +340,11 @@ FinsClient.prototype.status = function(callback) {
 
 
 FinsClient.prototype.close = function(){
-    this.socket.close();
+    if (this.timer) {
+        clearTimeout(this.timer);
+        this.timer = undefined;
+    }
+	this.socket.close();
 };
 
 

--- a/lib/fins_client.js
+++ b/lib/fins_client.js
@@ -276,7 +276,7 @@ FinsClient.prototype.read = function(address,regsToRead,callback) {
     var command = constants.Commands.MEMORY_AREA_READ;
     var commandData = [address,regsToRead];
     var packet = _buildPacket([header,command,commandData]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
@@ -290,7 +290,7 @@ FinsClient.prototype.write = function(address,dataToBeWritten,callback) {
     var dataToBeWritten = _wordsToBytes(dataToBeWritten);
     var commandData = [address,regsToWrite,dataToBeWritten];
     var packet = _buildPacket([header,command,commandData]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
@@ -304,7 +304,7 @@ FinsClient.prototype.fill = function(address,dataToBeWritten,regsToWrite,callbac
     var dataToBeWritten = _wordsToBytes(dataToBeWritten);
     var commandData = [address,regsToWrite,dataToBeWritten];
     var packet = _buildPacket([header,command,commandData]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
@@ -314,7 +314,7 @@ FinsClient.prototype.run = function(callback) {
     var header = _buildHeader(self.header);
     var command = constants.Commands.RUN;
     var packet = _buildPacket([header,command]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
@@ -324,7 +324,7 @@ FinsClient.prototype.stop = function(callback) {
     var header = _buildHeader(self.header);
     var command = constants.Commands.STOP;
     var packet = _buildPacket([header,command]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 
@@ -335,7 +335,7 @@ FinsClient.prototype.status = function(callback) {
     var header = _buildHeader(self.header);
     var command = constants.Commands.CONTROLLER_STATUS_READ;
     var packet = _buildPacket([header,command]);
-    var buffer = new Buffer(packet);
+    var buffer = Buffer.from(packet);
     this.socket.send(buffer,0,buffer.length,self.port,self.host,callback);
 };
 


### PR DESCRIPTION
The Buffer() and new Buffer() constructors are not recommended for use due to security and usability concerns. Changed to use Buffer.from() construction methods instead.

Added support for reading a bit from the PLC. This is based on @AwenChen work the main difference is that his code uses a varible isBit which is fine for a single read but you cant mix between reading a bit and then reading an int, as the _processMemoryAreaRead() method is run after all the _translateMemoryAddress() methods so the last address to be read will determine the value of isBit for all the reads regardless of whether it is a bit or an int. This version checks the length of the return buffer to determine whether the response is a bit or not.

Updated example.js to show use